### PR TITLE
don't resolve file path

### DIFF
--- a/bin/jsnice
+++ b/bin/jsnice
@@ -23,9 +23,9 @@ var args = docopt.docopt(doc, {
   help: true,
   version: 'jsnice ' + require('../package.json').version,
 });
-var cwd = process.cwd();
-filePath = path.join(cwd, args['<file>']);
 
+// Resolve file path
+var filePath = args['<file>'];
 var js = fs.readFileSync(filePath);
 var options = {
   pretty: !args['--no-pretty'],


### PR DESCRIPTION
Fixes #2 

Right now we are manually trying to resolve the provided path from `process.cwd()`, however, this is causing issues when provided with absolute paths. As well, `fs.readFileSync` will resolve relative paths from `process.cwd()` anyways, so we can remove this excess part.
